### PR TITLE
Move go module to github.com/crc-org/machine

### DIFF
--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -3,8 +3,8 @@ package fakedriver
 import (
 	"fmt"
 
-	"github.com/code-ready/machine/libmachine/drivers"
-	"github.com/code-ready/machine/libmachine/state"
+	"github.com/crc-org/machine/libmachine/drivers"
+	"github.com/crc-org/machine/libmachine/state"
 )
 
 type Driver struct {

--- a/drivers/libvirt/driver_linux.go
+++ b/drivers/libvirt/driver_linux.go
@@ -1,7 +1,7 @@
 package libvirt
 
 import (
-	"github.com/code-ready/machine/libmachine/drivers"
+	"github.com/crc-org/machine/libmachine/drivers"
 )
 
 type Driver struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/code-ready/machine
+module github.com/crc-org/machine
 
 require (
 	github.com/sirupsen/logrus v1.9.0

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -3,7 +3,7 @@ package drivers
 import (
 	"errors"
 
-	"github.com/code-ready/machine/libmachine/state"
+	"github.com/crc-org/machine/libmachine/state"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/code-ready/machine/libmachine/drivers"
-	"github.com/code-ready/machine/libmachine/drivers/plugin/localbinary"
-	rpcdriver "github.com/code-ready/machine/libmachine/drivers/rpc"
-	"github.com/code-ready/machine/libmachine/version"
+	"github.com/crc-org/machine/libmachine/drivers"
+	"github.com/crc-org/machine/libmachine/drivers/plugin/localbinary"
+	rpcdriver "github.com/crc-org/machine/libmachine/drivers/rpc"
+	"github.com/crc-org/machine/libmachine/version"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/code-ready/machine/libmachine/drivers"
-	"github.com/code-ready/machine/libmachine/drivers/plugin/localbinary"
-	"github.com/code-ready/machine/libmachine/state"
-	"github.com/code-ready/machine/libmachine/version"
+	"github.com/crc-org/machine/libmachine/drivers"
+	"github.com/crc-org/machine/libmachine/drivers/plugin/localbinary"
+	"github.com/crc-org/machine/libmachine/state"
+	"github.com/crc-org/machine/libmachine/version"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"runtime/debug"
 
-	"github.com/code-ready/machine/libmachine/drivers"
-	"github.com/code-ready/machine/libmachine/state"
-	"github.com/code-ready/machine/libmachine/version"
+	"github.com/crc-org/machine/libmachine/drivers"
+	"github.com/crc-org/machine/libmachine/state"
+	"github.com/crc-org/machine/libmachine/version"
 )
 
 type Stacker interface {

--- a/libmachine/drivers/rpc/server_driver_test.go
+++ b/libmachine/drivers/rpc/server_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/code-ready/machine/drivers/fakedriver"
+	"github.com/crc-org/machine/drivers/fakedriver"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This reflects the new location of the git repository.
This is being done because the code-ready branding is deprecated.